### PR TITLE
Crash when compiling with the -v flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,15 +35,16 @@ struct Args {
 }
 
 fn main() {
-    let ctx = sdl2::init().unwrap();
-    let mut chip8 = Chip8::new(&ctx);
-    let mut events = ctx.event_pump().unwrap();
 
     let args: Args = Docopt::new(USAGE)
         .and_then(|d|
             d.version(Some(format!("{} v{}", env!("CARGO_PKG_NAME"),  env!("CARGO_PKG_VERSION"))))
              .decode())
         .unwrap_or_else(|e| e.exit());
+
+    let ctx = sdl2::init().unwrap();
+    let mut chip8 = Chip8::new(&ctx);
+    let mut events = ctx.event_pump().unwrap();
 
     chip8.load_rom(&args.arg_file);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,9 @@ fn main() {
     let mut events = ctx.event_pump().unwrap();
 
     let args: Args = Docopt::new(USAGE)
-        .and_then(|d| d.decode())
+        .and_then(|d|
+            d.version(Some(format!("{} v{}", env!("CARGO_PKG_NAME"),  env!("CARGO_PKG_VERSION"))))
+             .decode())
         .unwrap_or_else(|e| e.exit());
 
     chip8.load_rom(&args.arg_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 #![allow(unused_variables)]
 
-mod chip8;
-mod screen;
-mod instruction;
-
 extern crate rustc_serialize;
 extern crate docopt;
 extern crate sdl2;
 extern crate num;
 extern crate rand;
 #[macro_use] extern crate enum_primitive as ep;
+
+mod chip8;
+mod screen;
+mod instruction;
 
 use docopt::Docopt;
 use sdl2::keyboard::Keycode;


### PR DESCRIPTION
The "version" string in docopts seems to Default to None, so the program continues and no version is printed, leading to a crash when no file is provided.

This PR changes this behavior to output the version in the `<name> v<version>` format.
## Example

```
$ chip8 -v
chip8 v0.1.0
```
